### PR TITLE
Encja Product - implementacja JDP201001-12

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/ProductController.java
+++ b/src/main/java/com/kodilla/ecommercee/ProductController.java
@@ -30,7 +30,7 @@ public class ProductController {
 
     }
 
-    @RequestMapping(method = RequestMethod.POST, value = "updateProduct")
+    @RequestMapping(method = RequestMethod.PUT, value = "updateProduct")
     public ProductDto updateProduct(@RequestBody ProductDto productDto) {
         return new ProductDto(1L, "Product test - update");
     }

--- a/src/main/java/com/kodilla/ecommercee/domain/Product.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Product.java
@@ -2,12 +2,21 @@ package com.kodilla.ecommercee.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
+@Entity(name = "product")
 
 public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
+    @Column(name = "productName")
     private String productName;
 
 }

--- a/src/main/java/com/kodilla/ecommercee/mapper/ProductMapper.java
+++ b/src/main/java/com/kodilla/ecommercee/mapper/ProductMapper.java
@@ -1,0 +1,25 @@
+package com.kodilla.ecommercee.mapper;
+
+import com.kodilla.ecommercee.domain.Product;
+import com.kodilla.ecommercee.domain.ProductDto;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ProductMapper {
+    public Product mapToProduct(final ProductDto productDto) {
+        return new Product(productDto.getId(), productDto.getProductName());
+    }
+
+    public ProductDto mapToProductDto(final Product product){
+        return new ProductDto(product.getId(), product.getProductName());
+    }
+
+    public List<ProductDto> mapToProductDtoList(final List<Product> productList) {
+        return productList.stream()
+                .map(l -> new ProductDto(l.getId(), l.getProductName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/kodilla/ecommercee/repository/ProductRepository.java
+++ b/src/main/java/com/kodilla/ecommercee/repository/ProductRepository.java
@@ -1,0 +1,23 @@
+package com.kodilla.ecommercee.repository;
+
+import com.kodilla.ecommercee.domain.Product;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductRepository extends CrudRepository<Product, Long> {
+
+    @Override
+    List<Product> findAll();
+
+    @Override
+    Optional<Product> findById(Long productId);
+
+    @Override
+    Product save(Product product);
+
+    @Override
+    void deleteById(Long productId);
+
+}


### PR DESCRIPTION
Utworzenie w klasie domenowej Product encji, Dodanie pakietu Repository i utworzenie interfejsu ProductRepository, utworzenie nowego pakietu rapper w którym dodałem klasę ProductMapper która służy do mapowania product na productDto i odwrotnie. 
Poprawiłem end point zgodnie z wczorajszymi ustaleniami w klasie ProdcutController (przy updacie z POST na PUT.